### PR TITLE
Improve tag detection for Cyanogenmod HCE

### DIFF
--- a/examples/mifare-desfire-info.c
+++ b/examples/mifare-desfire-info.c
@@ -132,7 +132,7 @@ main(int argc, char *argv[])
 		printf ("unknown\n");
 	    }
 
-	    printf ("Use random UID: %s\n", (strlen (tag_uid) / 2 == 4) ? "yes" : "no");
+	    printf ("Use random UID: %s\n", (strncmp (tag_uid, "08", 2) == 0) ? "yes" : "no");
 
 	    free (tag_uid);
 

--- a/libfreefare/freefare.c
+++ b/libfreefare/freefare.c
@@ -27,6 +27,7 @@
 #define MAX_CANDIDATES 16
 
 #define NXP_MANUFACTURER_CODE 0x04
+#define RANDOM_UID 0x08
 
 struct supported_tag supported_tags[] = {
     { FELICA,              "FeliCA",                       NMT_FELICA,    0x00, 0, 0, { 0x00 }, NULL },
@@ -36,8 +37,8 @@ struct supported_tag supported_tags[] = {
     { MIFARE_CLASSIC_1K,   "Infineon Mifare Classic 1k",   NMT_ISO14443A, 0x88, 0, 0, { 0x00 }, NULL },
     { MIFARE_CLASSIC_4K,   "Mifare Classic 4k",            NMT_ISO14443A, 0x18, 0, 0, { 0x00 }, NULL },
     { MIFARE_CLASSIC_4K,   "Mifare Classic 4k (Emulated)", NMT_ISO14443A, 0x38, 0, 0, { 0x00 }, NULL },
-    { MIFARE_DESFIRE,      "Mifare DESFire",               NMT_ISO14443A, 0x20, 5, 4, { 0x75, 0x77, 0x81, 0x02 /*, 0xXX */ }, NULL},
-    { MIFARE_DESFIRE,      "Cyanogenmod card emulation",   NMT_ISO14443A, 0x60, 4, 3, { 0x78, 0x33, 0x88 /*, 0xXX */ }, NULL},
+    { MIFARE_DESFIRE,      "Mifare DESFire",               NMT_ISO14443A, 0x20, 4, 0, { 0x75, 0x77, 0x81, 0x02 /*, 0xXX */ }, NULL},
+    { MIFARE_DESFIRE,      "Cyanogemod card emulation",    NMT_ISO14443A, 0x20, 3, 3, { 0x78, 0x33, 0x88 /*, 0xXX */ }, NULL},
     { MIFARE_DESFIRE,      "Android HCE",                  NMT_ISO14443A, 0x60, 4, 3, { 0x78, 0x80, 0x70 /*, 0xXX */ }, NULL},
     { MIFARE_ULTRALIGHT_C, "Mifare UltraLightC",           NMT_ISO14443A, 0x00, 0, 0, { 0x00 }, is_mifare_ultralightc_on_reader },
     { MIFARE_ULTRALIGHT,   "Mifare UltraLight",            NMT_ISO14443A, 0x00, 0, 0, { 0x00 }, NULL },
@@ -63,7 +64,7 @@ freefare_tag_new (nfc_device *device, nfc_target target)
 	    found = true;
 	    break;
 	}
-	if ((target.nm.nmt == NMT_ISO14443A) && ((target.nti.nai.szUidLen == 4) || (target.nti.nai.abtUid[0] == NXP_MANUFACTURER_CODE)) &&
+	if ((target.nm.nmt == NMT_ISO14443A) && ((target.nti.nai.szUidLen == 4) || (target.nti.nai.abtUid[0] == NXP_MANUFACTURER_CODE) || (target.nti.nai.abtUid[0] == RANDOM_UID)) &&
 	    (target.nti.nai.btSak == supported_tags[i].SAK) &&
 	    (!supported_tags[i].ATS_min_length || ((target.nti.nai.szAtsLen >= supported_tags[i].ATS_min_length) &&
 						   (0 == memcmp (target.nti.nai.abtAts, supported_tags[i].ATS, supported_tags[i].ATS_compare_length)))) &&


### PR DESCRIPTION
- It seemed that cyanogenmod random uids weren't properly detected by the mifare-desfire-version utility. I have added a check for random uid properly by checking for 08 prefix (as per the NXP spec) in the tag detection code
- Adapt Cyanogenmod SAK value (now the same as in the libnfc-nxp code), see 
  https://github.com/CyanogenMod/android_external_libnfc-nxp/blob/cm-12.1/inc/phNfcConfig.h:277
- There's still a bug remaining in the code for parsing a random uid. I might want to create an issue for this

The following request/response to a Desfire Android app I'm building yields the following result 

tamashell

```
> 4a 01 00
Tx: 4a  01  00  
Rx: 01  01  03  44  20  07  08  b0  57  a8  60  c0  99  05  78  33  88  00  
```

is parsed into 

```
===> Version information for tag 0843fd0ff8eba0:
UID:                      0x04913a29932680
Batch number:             0x0000000000
Production date:          week 39, 2008
```
