### PR TITLE
Various Cleanup

### DIFF
--- a/examples/felica-lite-dump.c
+++ b/examples/felica-lite-dump.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2015, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <err.h>
 #include <stdlib.h>
 

--- a/examples/felica-read-ndef.c
+++ b/examples/felica-read-ndef.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2015, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #if defined(HAVE_CONFIG_H)
 #  include "config.h"
 #endif

--- a/examples/mifare-classic-format.c
+++ b/examples/mifare-classic-format.c
@@ -1,21 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere, Romuald Conty.
- * Copyright (C) 2012, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #if defined(HAVE_CONFIG_H)
 #  include "config.h"
 #endif

--- a/examples/mifare-classic-read-ndef.c
+++ b/examples/mifare-classic-read-ndef.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2011, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 /*
  * This implementation was written based on information provided by the
  * following documents:

--- a/examples/mifare-classic-write-ndef.c
+++ b/examples/mifare-classic-write-ndef.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #if defined(HAVE_CONFIG_H)
 #  include "config.h"
 #endif

--- a/examples/mifare-desfire-access.c
+++ b/examples/mifare-desfire-access.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <err.h>
 #include <errno.h>
 #include <stdlib.h>

--- a/examples/mifare-desfire-create-ndef.c
+++ b/examples/mifare-desfire-create-ndef.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Audrey Diacre.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #if defined(HAVE_CONFIG_H)
 #  include "config.h"
 #endif

--- a/examples/mifare-desfire-ev1-configure-ats.c
+++ b/examples/mifare-desfire-ev1-configure-ats.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #if defined(HAVE_CONFIG_H)
 #  include "config.h"
 #endif

--- a/examples/mifare-desfire-ev1-configure-default-key.c
+++ b/examples/mifare-desfire-ev1-configure-default-key.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #if defined(HAVE_CONFIG_H)
 #  include "config.h"
 #endif

--- a/examples/mifare-desfire-ev1-configure-random-uid.c
+++ b/examples/mifare-desfire-ev1-configure-random-uid.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #if defined(HAVE_CONFIG_H)
 #  include "config.h"
 #endif

--- a/examples/mifare-desfire-format.c
+++ b/examples/mifare-desfire-format.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #if defined(HAVE_CONFIG_H)
 #  include "config.h"
 #endif

--- a/examples/mifare-desfire-info.c
+++ b/examples/mifare-desfire-info.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <err.h>
 #include <errno.h>
 #include <stdlib.h>

--- a/examples/mifare-desfire-read-ndef.c
+++ b/examples/mifare-desfire-read-ndef.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Audrey Diacre.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #if defined(HAVE_CONFIG_H)
 #  include "config.h"
 #endif

--- a/examples/mifare-desfire-write-ndef.c
+++ b/examples/mifare-desfire-write-ndef.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Audrey Diacre.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #if defined(HAVE_CONFIG_H)
 #  include "config.h"
 #endif

--- a/examples/mifare-ultralight-info.c
+++ b/examples/mifare-ultralight-info.c
@@ -1,19 +1,3 @@
-/*-
- * Copyright (C) 2012, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
 #include <err.h>
 #include <stdlib.h>
 

--- a/examples/ntag-detect.c
+++ b/examples/ntag-detect.c
@@ -1,19 +1,3 @@
-/*-
- * Copyright (C) 2012, 2017 Romain Tartiere, Martin Dagarin (SloCompTech).
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
 #include <err.h>
 #include <stdlib.h>
 

--- a/examples/ntag-removeauth.c
+++ b/examples/ntag-removeauth.c
@@ -1,19 +1,3 @@
-/*-
- * Copyright (C) 2012, 2017 Romain Tartiere, Martin Dagarin (SloCompTech).
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
 #include <err.h>
 #include <stdlib.h>
 

--- a/examples/ntag-setauth.c
+++ b/examples/ntag-setauth.c
@@ -1,19 +1,3 @@
-/*-
- * Copyright (C) 2012, 2017 Romain Tartiere, Martin Dagarin (SloCompTech).
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
 #include <err.h>
 #include <stdlib.h>
 

--- a/examples/ntag-write.c
+++ b/examples/ntag-write.c
@@ -1,19 +1,3 @@
-/*-
- * Copyright (C) 2012, 2017 Romain Tartiere, Martin Dagarin (SloCompTech).
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
 #include <err.h>
 #include <stdlib.h>
 

--- a/libfreefare/felica.c
+++ b/libfreefare/felica.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2015, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 /*
  * This implementation was written based on information provided by the
  * following documents:

--- a/libfreefare/freefare.c
+++ b/libfreefare/freefare.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #if defined(HAVE_CONFIG_H)
 #  include "config.h"
 #endif

--- a/libfreefare/freefare.h
+++ b/libfreefare/freefare.h
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2009, 2010, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #ifndef __FREEFARE_H__
 #define __FREEFARE_H__
 

--- a/libfreefare/freefare_internal.h
+++ b/libfreefare/freefare_internal.h
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #ifndef __FREEFARE_INTERNAL_H__
 #define __FREEFARE_INTERNAL_H__
 

--- a/libfreefare/mad.c
+++ b/libfreefare/mad.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2009, 2010, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 /*
  * This implementation was written based on information provided by the
  * following document:

--- a/libfreefare/mifare_application.c
+++ b/libfreefare/mifare_application.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2009, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 /*
  * This implementation was written based on information provided by the
  * following document:

--- a/libfreefare/mifare_classic.c
+++ b/libfreefare/mifare_classic.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2009, 2010, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 /*
  * This implementation was written based on information provided by the
  * following documents:

--- a/libfreefare/mifare_desfire.c
+++ b/libfreefare/mifare_desfire.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 /*
  * This implementation was written based on information provided by the
  * following documents:

--- a/libfreefare/mifare_desfire_aid.c
+++ b/libfreefare/mifare_desfire_aid.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 /*
  * This implementation was written based on information provided by the
  * following document:

--- a/libfreefare/mifare_desfire_crypto.c
+++ b/libfreefare/mifare_desfire_crypto.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 /*
  * This implementation was written based on information provided by the
  * following documents:

--- a/libfreefare/mifare_desfire_error.c
+++ b/libfreefare/mifare_desfire_error.c
@@ -1,21 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
-
 #include <sys/types.h>
 
 #include <stdlib.h>

--- a/libfreefare/mifare_desfire_key.c
+++ b/libfreefare/mifare_desfire_key.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <stdlib.h>
 #include <string.h>
 

--- a/libfreefare/mifare_ultralight.c
+++ b/libfreefare/mifare_ultralight.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 /*
  * This implementation was written based on information provided by the
  * following documents:

--- a/libfreefare/ntag21x.c
+++ b/libfreefare/ntag21x.c
@@ -14,7 +14,9 @@
  * June 2015
  */
 
-#include "config.h"
+#if defined(HAVE_CONFIG_H)
+#  include "config.h"
+#endif
 
 #if defined(HAVE_SYS_TYPES_H)
 #  include <sys/types.h>

--- a/libfreefare/ntag21x.c
+++ b/libfreefare/ntag21x.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2017, Martin Dagarin.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 /*
  * This implementation was written based on information provided by the
  * following documents:

--- a/libfreefare/tlv.c
+++ b/libfreefare/tlv.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 /*
  * This implementation was written based on information provided by the
  * following documents:

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -37,7 +37,7 @@ AM_LDFLAGS = -module -rpath $(libdir) -avoid-version -no-undefined
 
 test_felica_la_SOURCES = test_felica.c \
 			 felica_fixture.c \
-			 felica_fixture.h
+			 fixture.h
 test_felica_la_LIBADD = $(top_builddir)/libfreefare/libfreefare.la
 
 test_freefare_la_SOURCES = test_freefare.c
@@ -52,7 +52,7 @@ test_mifare_application_la_LIBADD = $(top_builddir)/libfreefare/libfreefare.la
 test_mifare_classic_la_SOURCES = test_mifare_classic.c \
 				 test_mifare_classic_mad.c \
 				 mifare_classic_fixture.c \
-				 mifare_classic_fixture.h
+				 fixture.h
 test_mifare_classic_la_LIBADD = $(top_builddir)/libfreefare/libfreefare.la
 
 test_mifare_classic_create_trailer_block_la_SOURCES = test_mifare_classic_create_trailer_block.c
@@ -63,7 +63,7 @@ test_mifare_classic_sector_boundaries_la_LIBADD = $(top_builddir)/libfreefare/li
 
 test_mifare_desfire_la_SOURCES = test_mifare_desfire.c \
 				 mifare_desfire_fixture.c \
-				 mifare_desfire_fixture.h
+				 fixture.h
 test_mifare_desfire_la_LIBADD = $(top_builddir)/libfreefare/libfreefare.la \
 				$(top_builddir)/test/common/libtestcommon.la
 
@@ -82,7 +82,7 @@ test_mifare_desfire_ev1_la_SOURCES = test_mifare_desfire_ev1.c \
 				     test_mifare_desfire_ev1_aes.c \
 				     test_mifare_desfire_ev1_iso.c \
 				     mifare_desfire_ev1_fixture.c \
-				     mifare_desfire_ev1_fixture.h
+				     fixture.h
 test_mifare_desfire_ev1_la_LIBADD = $(top_builddir)/libfreefare/libfreefare.la \
 				    $(top_builddir)/test/common/libtestcommon.la
 
@@ -91,7 +91,7 @@ test_mifare_desfire_key_la_LIBADD = $(top_builddir)/libfreefare/libfreefare.la
 
 test_mifare_ultralight_la_SOURCES = test_mifare_ultralight.c \
 				    mifare_ultralight_fixture.c \
-				    mifare_ultralight_fixture.h
+				    fixture.h
 test_mifare_ultralight_la_LIBADD = $(top_builddir)/libfreefare/libfreefare.la
 
 test_tlv_la_SOURCES = test_tlv.c

--- a/test/common/mifare_desfire_auto_authenticate.c
+++ b/test/common/mifare_desfire_auto_authenticate.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 
 #include <freefare.h>

--- a/test/common/mifare_desfire_auto_authenticate.h
+++ b/test/common/mifare_desfire_auto_authenticate.h
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #ifndef _MIFARE_DESFIRE_AUTO_AUTHENTICATE_H
 #define _MIFARE_DESFIRE_AUTO_AUTHENTICATE_H
 

--- a/test/felica_fixture.c
+++ b/test/felica_fixture.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2015, Romain Tartiere
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 #include <freefare.h>
 

--- a/test/felica_fixture.c
+++ b/test/felica_fixture.c
@@ -1,7 +1,7 @@
 #include <cutter.h>
 #include <freefare.h>
 
-#include "felica_fixture.h"
+#include "fixture.h"
 
 static nfc_context *context;
 static nfc_device *device = NULL;

--- a/test/felica_fixture.h
+++ b/test/felica_fixture.h
@@ -1,1 +1,0 @@
-extern FreefareTag tag;

--- a/test/felica_fixture.h
+++ b/test/felica_fixture.h
@@ -1,18 +1,1 @@
-/*-
- * Copyright (C) 2015, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 extern FreefareTag tag;

--- a/test/fixture.h
+++ b/test/fixture.h
@@ -1,0 +1,6 @@
+#ifndef _FIXTURE_H
+#define _FIXTURE_H
+
+extern FreefareTag tag;
+
+#endif /* _FIXTURE_H */

--- a/test/mifare_classic_fixture.c
+++ b/test/mifare_classic_fixture.c
@@ -1,21 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere
- * Copyright (C) 2013, Romuald Conty
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 #include <freefare.h>
 

--- a/test/mifare_classic_fixture.c
+++ b/test/mifare_classic_fixture.c
@@ -1,7 +1,7 @@
 #include <cutter.h>
 #include <freefare.h>
 
-#include "mifare_classic_fixture.h"
+#include "fixture.h"
 
 static nfc_context *context;
 static nfc_device *device = NULL;

--- a/test/mifare_classic_fixture.h
+++ b/test/mifare_classic_fixture.h
@@ -1,1 +1,0 @@
-extern FreefareTag tag;

--- a/test/mifare_classic_fixture.h
+++ b/test/mifare_classic_fixture.h
@@ -1,18 +1,1 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 extern FreefareTag tag;

--- a/test/mifare_desfire_ev1_fixture.c
+++ b/test/mifare_desfire_ev1_fixture.c
@@ -1,7 +1,7 @@
 #include <cutter.h>
 #include <freefare.h>
 
-#include "mifare_desfire_ev1_fixture.h"
+#include "fixture.h"
 
 static nfc_context *context;
 static nfc_device *device = NULL;

--- a/test/mifare_desfire_ev1_fixture.c
+++ b/test/mifare_desfire_ev1_fixture.c
@@ -1,21 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere
- * Copyright (C) 2013, Romuald Conty
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 #include <freefare.h>
 

--- a/test/mifare_desfire_ev1_fixture.h
+++ b/test/mifare_desfire_ev1_fixture.h
@@ -1,1 +1,0 @@
-extern FreefareTag tag;

--- a/test/mifare_desfire_ev1_fixture.h
+++ b/test/mifare_desfire_ev1_fixture.h
@@ -1,18 +1,1 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 extern FreefareTag tag;

--- a/test/mifare_desfire_fixture.c
+++ b/test/mifare_desfire_fixture.c
@@ -1,21 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere
- * Copyright (C) 2013, Romuald Conty
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 #include <freefare.h>
 

--- a/test/mifare_desfire_fixture.c
+++ b/test/mifare_desfire_fixture.c
@@ -1,7 +1,7 @@
 #include <cutter.h>
 #include <freefare.h>
 
-#include "mifare_desfire_fixture.h"
+#include "fixture.h"
 
 static nfc_context *context;
 static nfc_device *device = NULL;

--- a/test/mifare_desfire_fixture.h
+++ b/test/mifare_desfire_fixture.h
@@ -1,1 +1,0 @@
-extern FreefareTag tag;

--- a/test/mifare_desfire_fixture.h
+++ b/test/mifare_desfire_fixture.h
@@ -1,18 +1,1 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 extern FreefareTag tag;

--- a/test/mifare_ultralight_fixture.c
+++ b/test/mifare_ultralight_fixture.c
@@ -1,7 +1,7 @@
 #include <cutter.h>
 #include <freefare.h>
 
-#include "mifare_ultralight_fixture.h"
+#include "fixture.h"
 
 static nfc_context *context;
 static nfc_device *device = NULL;

--- a/test/mifare_ultralight_fixture.c
+++ b/test/mifare_ultralight_fixture.c
@@ -1,21 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere
- * Copyright (C) 2013, Romuald Conty
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 #include <freefare.h>
 

--- a/test/mifare_ultralight_fixture.h
+++ b/test/mifare_ultralight_fixture.h
@@ -1,1 +1,0 @@
-extern FreefareTag tag;

--- a/test/mifare_ultralight_fixture.h
+++ b/test/mifare_ultralight_fixture.h
@@ -1,18 +1,1 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 extern FreefareTag tag;

--- a/test/test_felica.c
+++ b/test/test_felica.c
@@ -2,7 +2,7 @@
 
 #include <freefare.h>
 
-#include "felica_fixture.h"
+#include "fixture.h"
 
 void
 test_felica_read_without_encryption(void)

--- a/test/test_mad.c
+++ b/test/test_mad.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2009, 2010, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 
 #include <freefare.h>

--- a/test/test_mifare_application.c
+++ b/test/test_mifare_application.c
@@ -1,19 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
 #include <cutter.h>
 
 #include <freefare.h>

--- a/test/test_mifare_classic.c
+++ b/test/test_mifare_classic.c
@@ -5,7 +5,7 @@
 #include <freefare.h>
 #include "freefare_internal.h"
 
-#include "mifare_classic_fixture.h"
+#include "fixture.h"
 
 void
 test_mifare_classic_authenticate(void)

--- a/test/test_mifare_classic.c
+++ b/test/test_mifare_classic.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 #include <string.h>
 #include <strings.h>

--- a/test/test_mifare_classic_create_trailer_block.c
+++ b/test/test_mifare_classic_create_trailer_block.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 
 #include <freefare.h>

--- a/test/test_mifare_classic_mad.c
+++ b/test/test_mifare_classic_mad.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 
 #include <freefare.h>

--- a/test/test_mifare_classic_mad.c
+++ b/test/test_mifare_classic_mad.c
@@ -2,7 +2,7 @@
 
 #include <freefare.h>
 
-#include "mifare_classic_fixture.h"
+#include "fixture.h"
 
 void
 test_mifare_classic_mad(void)

--- a/test/test_mifare_classic_sector_boundaries.c
+++ b/test/test_mifare_classic_sector_boundaries.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 
 #include <freefare.h>

--- a/test/test_mifare_desfire.c
+++ b/test/test_mifare_desfire.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 #include <errno.h>
 #include <string.h>

--- a/test/test_mifare_desfire.c
+++ b/test/test_mifare_desfire.c
@@ -6,7 +6,7 @@
 #include <freefare.h>
 #include "freefare_internal.h"
 
-#include "mifare_desfire_fixture.h"
+#include "fixture.h"
 #include "common/mifare_desfire_auto_authenticate.h"
 
 #define cut_assert_success(last_command) \

--- a/test/test_mifare_desfire_aes.c
+++ b/test/test_mifare_desfire_aes.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 /*
  * These tests implement examples provided in the following documents:
  *

--- a/test/test_mifare_desfire_aid.c
+++ b/test/test_mifare_desfire_aid.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <freefare.h>
 #include <cutter.h>
 

--- a/test/test_mifare_desfire_des.c
+++ b/test/test_mifare_desfire_des.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 #include <freefare.h>
 #include "freefare_internal.h"

--- a/test/test_mifare_desfire_ev1.c
+++ b/test/test_mifare_desfire_ev1.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 #include <errno.h>
 #include <string.h>

--- a/test/test_mifare_desfire_ev1.c
+++ b/test/test_mifare_desfire_ev1.c
@@ -6,7 +6,7 @@
 #include <freefare.h>
 #include "freefare_internal.h"
 
-#include "mifare_desfire_ev1_fixture.h"
+#include "fixture.h"
 #include "common/mifare_desfire_auto_authenticate.h"
 
 #define cut_assert_success(last_command) \

--- a/test/test_mifare_desfire_ev1_3des.c
+++ b/test/test_mifare_desfire_ev1_3des.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 #include <errno.h>
 #include <string.h>

--- a/test/test_mifare_desfire_ev1_3des.c
+++ b/test/test_mifare_desfire_ev1_3des.c
@@ -6,7 +6,7 @@
 #include <freefare.h>
 #include "freefare_internal.h"
 
-#include "mifare_desfire_ev1_fixture.h"
+#include "fixture.h"
 #include "common/mifare_desfire_auto_authenticate.h"
 
 #define cut_assert_success(last_command) \

--- a/test/test_mifare_desfire_ev1_3k3des.c
+++ b/test/test_mifare_desfire_ev1_3k3des.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 #include <errno.h>
 #include <string.h>

--- a/test/test_mifare_desfire_ev1_3k3des.c
+++ b/test/test_mifare_desfire_ev1_3k3des.c
@@ -6,7 +6,7 @@
 #include <freefare.h>
 #include "freefare_internal.h"
 
-#include "mifare_desfire_ev1_fixture.h"
+#include "fixture.h"
 #include "common/mifare_desfire_auto_authenticate.h"
 
 #define cut_assert_success(last_command) \

--- a/test/test_mifare_desfire_ev1_aes.c
+++ b/test/test_mifare_desfire_ev1_aes.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 #include <errno.h>
 #include <string.h>

--- a/test/test_mifare_desfire_ev1_aes.c
+++ b/test/test_mifare_desfire_ev1_aes.c
@@ -6,7 +6,7 @@
 #include <freefare.h>
 #include "freefare_internal.h"
 
-#include "mifare_desfire_ev1_fixture.h"
+#include "fixture.h"
 #include "common/mifare_desfire_auto_authenticate.h"
 
 #define cut_assert_success(last_command) \

--- a/test/test_mifare_desfire_ev1_iso.c
+++ b/test/test_mifare_desfire_ev1_iso.c
@@ -3,7 +3,7 @@
 #include <freefare.h>
 #include "freefare_internal.h"
 
-#include "mifare_desfire_ev1_fixture.h"
+#include "fixture.h"
 #include "common/mifare_desfire_auto_authenticate.h"
 
 #define cut_assert_success(last_command) \

--- a/test/test_mifare_desfire_ev1_iso.c
+++ b/test/test_mifare_desfire_ev1_iso.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2011, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 
 #include <freefare.h>

--- a/test/test_mifare_desfire_key.c
+++ b/test/test_mifare_desfire_key.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 
 #include <freefare.h>

--- a/test/test_mifare_ultralight.c
+++ b/test/test_mifare_ultralight.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 #include <errno.h>
 #include <string.h>

--- a/test/test_mifare_ultralight.c
+++ b/test/test_mifare_ultralight.c
@@ -5,7 +5,7 @@
 #include <freefare.h>
 #include "freefare_internal.h"
 
-#include "mifare_ultralight_fixture.h"
+#include "fixture.h"
 
 void
 test_mifare_ultralight_write(void)

--- a/test/test_tlv.c
+++ b/test/test_tlv.c
@@ -1,20 +1,3 @@
-/*-
- * Copyright (C) 2010, Romain Tartiere, Romuald Conty.
- *
- * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version.
- *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
- * more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
 #include <cutter.h>
 
 #include <freefare.h>


### PR DESCRIPTION
Hello !

In my opinion, the copyright comments on top of each file provides nothing but clutter.  What about dropping them (the COPYRIGHT file already says what the user can do, and the VCS information is more accurate than the dates in these comments) ?

I did not touched files in the `contrib` directory for obvious reasons.  Before merging this, I would like to be sure that no contributor gets offended by this.  Please follow-up quickly if it's a concern for you !
