### PR TITLE
Add support for Mifare Mini 0.3k

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you are new to _libfreefare_ or the _nfc-tools_, you should collect useful in
 | MIFARE DESFire 4k   | Supported     |
 | MIFARE DESFire 8k   | Supported     |
 | MIFARE DESFire EV1  | Supported     |
-| MIFARE Mini         | Not supported |
+| MIFARE Mini         | Supported     |
 | MIFARE Plus S 2k    | Not supported |
 | MIFARE Plus S 4k    | Not supported |
 | MIFARE Plus X 2k    | Not supported |

--- a/libfreefare/freefare.3
+++ b/libfreefare/freefare.3
@@ -51,6 +51,7 @@ Mifare card manipulation library (libfreefare, \-lfreefare)
 .Bd -literal
 enum freefare_tag_type {
     FELICA,
+    MIFARE_MINI
     MIFARE_CLASSIC_1K,
     MIFARE_CLASSIC_4K,
     MIFARE_DESFIRE,

--- a/libfreefare/freefare.c
+++ b/libfreefare/freefare.c
@@ -38,6 +38,8 @@ freefare_tag_new (nfc_device *device, nfc_target target)
 
     if (felica_taste (device, target)) {
 	tag = felica_tag_new (device, target);
+    } else if (mifare_mini_taste (device, target)) {
+    tag = mifare_mini_tag_new (device, target);
     } else if (mifare_classic1k_taste (device, target)) {
 	tag = mifare_classic1k_tag_new (device, target);
     } else if (mifare_classic4k_taste (device, target)) {
@@ -155,6 +157,8 @@ freefare_get_tag_friendly_name (FreefareTag tag)
     switch (tag->type) {
     case FELICA:
 	return "FeliCA";
+    case MIFARE_MINI:
+    return "Mifare Mini 0.3k";
     case MIFARE_CLASSIC_1K:
 	return "Mifare Classic 1k";
     case MIFARE_CLASSIC_4K:

--- a/libfreefare/freefare.h
+++ b/libfreefare/freefare.h
@@ -30,7 +30,7 @@
 
 enum freefare_tag_type {
     FELICA,
-//    MIFARE_MINI,
+    MIFARE_MINI,
     MIFARE_CLASSIC_1K,
     MIFARE_CLASSIC_4K,
     MIFARE_DESFIRE,

--- a/libfreefare/freefare.h
+++ b/libfreefare/freefare.h
@@ -104,8 +104,10 @@ bool		 is_mifare_ultralightc_on_reader (nfc_device *device, nfc_iso14443a_info n
 
 
 
+bool             mifare_mini_taste (nfc_device *device, nfc_target target);
 bool		 mifare_classic1k_taste (nfc_device *device, nfc_target target);
 bool		 mifare_classic4k_taste (nfc_device *device, nfc_target target);
+FreefareTag      mifare_mini_tag_new (nfc_device *device, nfc_target target);
 FreefareTag	 mifare_classic1k_tag_new (nfc_device *device, nfc_target target);
 FreefareTag	 mifare_classic4k_tag_new (nfc_device *device, nfc_target target);
 void		 mifare_classic_tag_free (FreefareTag tag);

--- a/libfreefare/mifare_classic.c
+++ b/libfreefare/mifare_classic.c
@@ -194,6 +194,16 @@ int		 get_block_access_bits (FreefareTag tag, const MifareClassicBlockNumber blo
  */
 
 bool
+mifare_mini_taste (nfc_device *device, nfc_target target)
+{
+    (void) device;
+    return target.nm.nmt == NMT_ISO14443A &&
+    (
+     target.nti.nai.btSak == 0x09
+    );    
+}
+
+bool
 mifare_classic1k_taste (nfc_device *device, nfc_target target)
 {
     (void) device;
@@ -235,6 +245,13 @@ _mifare_classic_tag_new (nfc_device *device, nfc_target target, int tag_type)
     }
 
     return tag;
+}
+
+
+FreefareTag
+mifare_mini_tag_new (nfc_device *device, nfc_target target)
+{
+    return _mifare_classic_tag_new (device, target, MIFARE_MINI);
 }
 
 FreefareTag


### PR DESCRIPTION
Mifare Mini is the same as Mifare Classic, the only difference is about the memory size (Sector number).
Instructions are the same.
Easy patch 👍 