### PR TITLE
mifare_desfire_key: fix get/set_version for AES keys

### DIFF
--- a/libfreefare/mifare_desfire_key.c
+++ b/libfreefare/mifare_desfire_key.c
@@ -114,6 +114,9 @@ mifare_desfire_key_get_version(MifareDESFireKey key)
 {
     uint8_t version = 0;
 
+    if (key->type == T_AES)
+	return key->aes_version;
+
     for (int n = 0; n < 8; n++) {
 	version |= ((key->data[n] & 1) << (7 - n));
     }
@@ -124,6 +127,11 @@ mifare_desfire_key_get_version(MifareDESFireKey key)
 void
 mifare_desfire_key_set_version(MifareDESFireKey key, uint8_t version)
 {
+    if (key->type == T_AES) {
+	key->aes_version = version;
+	return;
+    }
+
     for (int n = 0; n < 8; n++) {
 	uint8_t version_bit = ((version & (1 << (7 - n))) >> (7 - n));
 	key->data[n] &= 0xfe;


### PR DESCRIPTION
mifare_desfire_key_set_version incorrectly modified AES key bytes, while mifare_desfire_key_get_version returned some bits of the AES key.