### PR TITLE
Fixed missprint

### DIFF
--- a/libfreefare/mifare_classic.c
+++ b/libfreefare/mifare_classic.c
@@ -526,7 +526,7 @@ mifare_classic_transfer(FreefareTag tag, const MifareClassicBlockNumber block)
      * meaning that the action was performed correctly (e.g. Snapper Feeder,
      * SCL 3711).
      */
-    if (!BUFFER_SIZE(res) || ((BUFFER_SIZE(res) == 1) && (res[0] = MC_OK)))
+    if (!BUFFER_SIZE(res) || ((BUFFER_SIZE(res) == 1) && (res[0] == MC_OK)))
 	return 0;
     else
 	return res[0];


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A warning, found using PVS-Studio:
libfreefare/libfreefare/mifare_classic.c    529     warn    V560 A part of conditional expression is always true: (res[0] = 0x0A).