### PR TITLE
Fixed unknown tag issues for NTAG21x

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -37,6 +37,8 @@ that you don't have to care about indentation anymore. For more details, please
 read the [style(9) man page from FreeBSD's
 website](http://www.freebsd.org/cgi/man.cgi?query=style).
 
+For style correction install package `astyle`. Then run `make style`.
+
 ## Write tests
 
 I already told you cutter is lovely, so you really should use it!  If you want

--- a/examples/mifare-desfire-ev1-configure-random-uid.c
+++ b/examples/mifare-desfire-ev1-configure-random-uid.c
@@ -153,8 +153,8 @@ main(int argc, char *argv[])
 		    }
 		}
 		break;
-	    case 4: // Random UID
-	    {} // Compilation fails if label is directly followed by the declaration rather than a statement
+	    case 4: { // Random UID
+	    } // Compilation fails if label is directly followed by the declaration rather than a statement
 	    MifareDESFireKey key_picc = mifare_desfire_des_key_new_with_version(key_data_picc);
 	    res = mifare_desfire_authenticate(tags[i], 0, key_picc);
 	    if (res < 0) {

--- a/libfreefare/CMakeLists.txt
+++ b/libfreefare/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY_SOURCES
 		mifare_key_deriver
 		mifare_ultralight
 		ntag21x
+		ntag21x_error
 		tlv
 		../contrib/libutil/hexdump
 		)

--- a/libfreefare/Makefile.am
+++ b/libfreefare/Makefile.am
@@ -16,6 +16,7 @@ libfreefare_la_SOURCES = felica.c \
 			 mad.c \
 			 mifare_application.c \
 			 ntag21x.c \
+			 ntag21x_error.c \
 			 tlv.c
 libfreefare_la_LIBADD =
 

--- a/libfreefare/freefare.c
+++ b/libfreefare/freefare.c
@@ -225,6 +225,8 @@ freefare_strerror(FreefareTag tag)
 	    } else if (MIFARE_DESFIRE(tag)->last_picc_error) {
 		p = mifare_desfire_error_lookup(MIFARE_DESFIRE(tag)->last_picc_error);
 	    }
+	} else if (tag->type == NTAG_21x) {
+	    p = ntag21x_error_lookup(NTAG_21x(tag)->last_error);
 	}
     }
     return p;

--- a/libfreefare/freefare.h
+++ b/libfreefare/freefare.h
@@ -93,6 +93,7 @@ bool		 is_mifare_ultralightc_on_reader(nfc_device *device, nfc_iso14443a_info na
 
 
 bool		 ntag21x_taste(nfc_device *device, nfc_target target);
+uint8_t		 ntag21x_last_error(FreefareTag tag);
 
 /* NTAG21x access features */
 #define NTAG_PROT 0x80
@@ -102,6 +103,7 @@ bool		 ntag21x_taste(nfc_device *device, nfc_target target);
 #define NTAG_AUTHLIM 0x07
 
 enum ntag_tag_subtype {
+    NTAG_UNKNOWN,
     NTAG_213,
     NTAG_215,
     NTAG_216
@@ -367,6 +369,8 @@ bit 0: PICC master key frozen (reversible with configuration change or when form
 /* Error code managed by the library */
 
 #define CRYPTO_ERROR            0x01
+#define TAG_INFO_MISSING_ERROR	0xBA
+#define UNKNOWN_TAG_TYPE_ERROR	0xBB
 
 struct mifare_desfire_aid;
 typedef struct mifare_desfire_aid *MifareDESFireAID;

--- a/libfreefare/freefare_internal.h
+++ b/libfreefare/freefare_internal.h
@@ -243,12 +243,16 @@ struct ntag21x_tag {
     uint8_t minor_product_version;
     uint8_t storage_size;
     uint8_t protocol_type;
+
+    uint8_t last_error;
 };
 
 struct ntag21x_key {
     uint8_t data[4]; // 4B key
     uint8_t pack[2]; // 2B Password Acknowlege
 };
+
+const char      *ntag21x_error_lookup(uint8_t code);
 
 /*
  * FreefareTag assertion macros

--- a/libfreefare/ntag21x_error.c
+++ b/libfreefare/ntag21x_error.c
@@ -1,0 +1,41 @@
+#include <sys/types.h>
+
+#include <stdlib.h>
+
+#include <freefare.h>
+
+#include "freefare_internal.h"
+
+#define EM(e) { e, #e }
+
+static struct ntag21x_error_message {
+    uint8_t code;
+    const char *message;
+} ntag21x_error_messages[] = {
+    EM(OPERATION_OK),
+    EM(TAG_INFO_MISSING_ERROR),
+    EM(UNKNOWN_TAG_TYPE_ERROR),
+    { 0, NULL }
+};
+
+const char *
+ntag21x_error_lookup(uint8_t code)
+{
+    struct ntag21x_error_message *e = ntag21x_error_messages;
+    while (e->message) {
+	if (e->code == code)
+	    return (e->message);
+	e++;
+    }
+
+    return "Invalid error code";
+}
+
+uint8_t
+ntag21x_last_error(FreefareTag tag)
+{
+    if (tag->type != NTAG_21x)
+	return 0;
+
+    return NTAG_21x(tag)->last_error;
+}

--- a/test/fixture.h
+++ b/test/fixture.h
@@ -1,6 +1,6 @@
 #ifndef _FIXTURE_H
-#define _FIXTURE_H
+    #define _FIXTURE_H
 
-extern FreefareTag tag;
+    extern FreefareTag tag;
 
 #endif /* _FIXTURE_H */


### PR DESCRIPTION
Hi,
I fixed some security issues for NTAG21x tags:
- created default tag type `NTAG_UNKNOWN` so unknown tags can be detected and addressed with switch or if
- fixed reuse function which used to reset all tag info
- added new tag type in assert valid page macro

Cheers