### PR TITLE
Fix GET_VERSION command for NTAG devices

### DIFF
--- a/libfreefare/ntag21x.c
+++ b/libfreefare/ntag21x.c
@@ -712,10 +712,9 @@ bool
 ntag21x_is_auth_supported(nfc_device *device, nfc_iso14443a_info nai)
 {
     int ret;
-    uint8_t cmd_step1[2];
+    uint8_t cmd_step1[1];
     uint8_t res_step1[8];
     cmd_step1[0] = 0x60;
-    cmd_step1[1] = 0x00;
 
     nfc_target pnti;
     nfc_modulation modulation = {


### PR DESCRIPTION
The spec claims that this is a 1-byte command, and testing on a PN532 via SPI validated that the one byte command is correct.