### PR TITLE
Add support for JCOP cards with DESFire emulation

### DIFF
--- a/libfreefare/mifare_desfire.c
+++ b/libfreefare/mifare_desfire.c
@@ -227,11 +227,19 @@ le24toh(uint8_t data[3])
 bool
 mifare_desfire_taste(nfc_device *device, nfc_target target)
 {
+    // We have two different ATS prefixes to
+    // check for, standalone and JCOP.
+    static const char STANDALONE_DESFIRE[] = { 0x75, 0x77, 0x81, 0x02};
+    static const char JCOP_DESFIRE[] = { 0x75, 0xf7, 0xb1, 0x02 };
+
     (void) device;
+
     return target.nm.nmt == NMT_ISO14443A &&
 	   target.nti.nai.btSak == 0x20 &&
-	   target.nti.nai.szAtsLen >= 5 &&
-	   memcmp(target.nti.nai.abtAts, "\x75\x77\x81\x02", 4) == 0;
+	   target.nti.nai.szAtsLen >= 5 && (
+	       memcmp(target.nti.nai.abtAts, STANDALONE_DESFIRE, sizeof(STANDALONE_DESFIRE)) == 0 ||
+	       memcmp(target.nti.nai.abtAts, JCOP_DESFIRE, sizeof(JCOP_DESFIRE)) == 0
+	   );
 }
 
 


### PR DESCRIPTION
Some JCOP cards (like [this one](https://www.smartcardfocus.us/shop/ilp/id~687/j3d081-80k/p/index.shtml)) support native DESFire emulation, but the existing code was ignoring these cards because they didn't have the expected ATS prefix.

This change updates `mifare_desfire_taste` to also return true for JCOP cards with DESFire support, allowing them to be used with libfreefare.