### PR TITLE
Fix build with libnfc <= 1.7.1

### DIFF
--- a/libfreefare/freefare.c
+++ b/libfreefare/freefare.c
@@ -186,13 +186,7 @@ freefare_get_tag_uid(FreefareTag tag)
 		snprintf(res + 2 * i, 3, "%02x", tag->info.nti.nai.abtUid[i]);
 	}
 	break;
-    case NMT_DEP:
-    case NMT_ISO14443B2CT:
-    case NMT_ISO14443B2SR:
-    case NMT_ISO14443B:
-    case NMT_ISO14443BI:
-    case NMT_JEWEL:
-    case NMT_BARCODE:
+    default:
 	res = strdup("UNKNOWN");
     }
     return res;

--- a/libfreefare/mifare_key_deriver.c
+++ b/libfreefare/mifare_key_deriver.c
@@ -133,13 +133,7 @@ mifare_key_deriver_update_uid(MifareKeyDeriver deriver, FreefareTag tag)
 	uid_data = tag->info.nti.nai.abtUid;
 	uid_len = tag->info.nti.nai.szUidLen;
 	break;
-    case NMT_DEP:
-    case NMT_ISO14443B2CT:
-    case NMT_ISO14443B2SR:
-    case NMT_ISO14443B:
-    case NMT_ISO14443BI:
-    case NMT_JEWEL:
-    case NMT_BARCODE:
+    default:
 	ret = -1;
 	errno = EINVAL;
 	break;


### PR DESCRIPTION
NMT_BARCODE was used only in error paths, so just use a default case to restore compatibility.

Fixes #83, fixes #84, fixes #88.