### PR TITLE
support of a new ATS for DESFire EV1 on JCOP3

### DIFF
--- a/libfreefare/mifare_desfire.c
+++ b/libfreefare/mifare_desfire.c
@@ -271,18 +271,20 @@ le24toh(uint8_t data[3])
 bool
 mifare_desfire_taste(nfc_device *device, nfc_target target)
 {
-    // We have two different ATS prefixes to
-    // check for, standalone and JCOP.
-    static const char STANDALONE_DESFIRE[] = { 0x75, 0x77, 0x81, 0x02};
+    // We have three different ATS prefixes to
+    // check for, standalone, JCOP and JCOP3.
+    static const char STANDALONE_DESFIRE[] = { 0x75, 0x77, 0x81, 0x02 };
     static const char JCOP_DESFIRE[] = { 0x75, 0xf7, 0xb1, 0x02 };
+    static const char JCOP3_DESFIRE[] = { 0x78, 0x77, 0x71, 0x02 };
 
     (void) device;
 
     return target.nm.nmt == NMT_ISO14443A &&
 	   target.nti.nai.btSak == 0x20 &&
-	   target.nti.nai.szAtsLen >= 5 && (
+	   target.nti.nai.szAtsLen >= 4 && (
 	       memcmp(target.nti.nai.abtAts, STANDALONE_DESFIRE, sizeof(STANDALONE_DESFIRE)) == 0 ||
-	       memcmp(target.nti.nai.abtAts, JCOP_DESFIRE, sizeof(JCOP_DESFIRE)) == 0
+	       memcmp(target.nti.nai.abtAts, JCOP_DESFIRE, sizeof(JCOP_DESFIRE)) == 0 ||
+	       memcmp(target.nti.nai.abtAts, JCOP3_DESFIRE, sizeof(JCOP3_DESFIRE)) == 0
 	   );
 }
 


### PR DESCRIPTION
Adding support of a new ATS sent by a DESFire EV1 applet found on a JCOP3 P60 chip.
Changing the minimum ATS length because of this applet.